### PR TITLE
iOSのタッチずれ問題修正

### DIFF
--- a/traQ-R second/AppDelegate.swift
+++ b/traQ-R second/AppDelegate.swift
@@ -51,17 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         // Override point for customization after application launch.
-        if #available(iOS 12.0, *) {
-            // Deal with wrong offset after keyboard disappears
-            // See: https://github.com/ionic-team/capacitor/issues/814#issuecomment-441607213
-            NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(self.keyboardWillHide(notification:)),
-                name: UIResponder.keyboardWillHideNotification,
-                object: nil
-            )
-        }
-        
         return true
     }
     
@@ -104,18 +93,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        if #available(iOS 12.0, *) {
-            for v in self.webView.subviews {
-                if !(v is UIScrollView) {
-                    continue
-                }
-                let scrollView = v as! UIScrollView
-                scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
-            }
-        }
     }
 }
 

--- a/traQ-R second/AppDelegate.swift
+++ b/traQ-R second/AppDelegate.swift
@@ -50,6 +50,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             application.registerForRemoteNotifications()
         }
         
+        // Override point for customization after application launch.
+        if #available(iOS 12.0, *) {
+            // Deal with wrong offset after keyboard disappears
+            // See: https://github.com/ionic-team/capacitor/issues/814#issuecomment-441607213
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.keyboardWillHide(notification:)),
+                name: UIResponder.keyboardWillHideNotification,
+                object: nil
+            )
+        }
+        
         return true
     }
     
@@ -92,6 +104,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        if #available(iOS 12.0, *) {
+            for v in self.webView.subviews {
+                if !(v is UIScrollView) {
+                    continue
+                }
+                let scrollView = v as! UIScrollView
+                scrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
キーボードが隠れる際にUKWebViewの位置は戻るが内部のUIScrollViewのオフセットが戻っていないので、setContentOffsetで戻してあげる

See: https://github.com/ionic-team/capacitor/issues/814#issuecomment-441607213